### PR TITLE
Update Inline Source package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "axios": "^0.19.0",
     "chai": "^4.2.0",
     "commander": "^2.20.0",
-    "inline-source": "^6.2.0",
+    "inline-source": "^7.1.0",
     "ipfs-unixfs": "^0.1.16",
     "ipld-dag-pb": "^0.17.4",
     "mime": "^2.4.4",


### PR DESCRIPTION
Update Inline Source to [fix link bug](https://github.com/popeindustries/inline-source/releases) ```[breaking] strictly parse <link> tag's rel attribute, allowing only stylesheet or icon. A missing rel attribute is still treated as stylesheet```