### PR TITLE
Fix inline css handling

### DIFF
--- a/src/parsers/text-html.ts
+++ b/src/parsers/text-html.ts
@@ -98,7 +98,7 @@ const importRemoteImages = async (entry: File, source: Source, context: any, log
 const importCssUrls = async (entry: File, source: Source, context: any, logger: Function): Promise<void> =>  {
 
     let css = source.fileContent as string;
-    let output = `<style>\n${css}\n</style>`;
+    let output = css;
 
     const urlRegexGlobal = /.*url\(([^\)]+)\).*/gi;
 
@@ -201,7 +201,9 @@ const importCssUrls = async (entry: File, source: Source, context: any, logger: 
         }
     }
 
-    source.content = output;
+    if (output !== css) {
+        source.content = `<style>\n${output}\n</style>`
+    }
 }
 
 async function downloadRemote(url: string): Promise<{data: Buffer, type: string}>{


### PR DESCRIPTION
Skip the assignment to `source.content` if no images were found in the CSS file. This makes it possible to consider _inlineSource_ options, e.g. [compress: true](https://github.com/ArweaveTeam/arweave-deploy/blob/1c14e7f20eaa2a737003864b744c4d1d0cf00a02/src/parsers/text-html.ts#L25).

**Before patch**
Inline CSS _is not_ compressed/minified.

**After patch**
Inline CSS _is_ compressed/minified.

And because every byte costs money, this patch is very important. 